### PR TITLE
SpiderStream updates 20260510 from hotfix/psi_050926 71d1e6c502

### DIFF
--- a/cpp/include/SpiderRock/DataFeed/CoreMessages.h
+++ b/cpp/include/SpiderRock/DataFeed/CoreMessages.h
@@ -1443,7 +1443,7 @@ private:
 		Int prtClusterNum;
 		Int prtClusterSize;
 		Byte prtType;
-		String<18> printCodes;
+		String<36> printCodes;
 		UShort prtOrders;
 		Int prtVolume;
 		Int cxlVolume;
@@ -1480,7 +1480,7 @@ public:
 	inline Int prtClusterNum() const { return layout_.prtClusterNum; }
 	inline Int prtClusterSize() const { return layout_.prtClusterSize; }
 	inline Byte prtType() const { return layout_.prtType; }
-	inline const String<18>& printCodes() const { return layout_.printCodes; }
+	inline const String<36>& printCodes() const { return layout_.printCodes; }
 	inline UShort prtOrders() const { return layout_.prtOrders; }
 	inline Int prtVolume() const { return layout_.prtVolume; }
 	inline Int cxlVolume() const { return layout_.cxlVolume; }
@@ -1541,7 +1541,7 @@ private:
 	{
 		Key pkey;
 		OptExch prtExch;
-		String<18> printCodes;
+		String<36> printCodes;
 		Int prtSize;
 		Float prtPrice;
 		Int prtClusterNum;
@@ -1587,7 +1587,7 @@ public:
 	inline uint64_t time_received() const { return time_received_; }
 	
 	inline OptExch prtExch() const { return layout_.prtExch; }
-	inline const String<18>& printCodes() const { return layout_.printCodes; }
+	inline const String<36>& printCodes() const { return layout_.printCodes; }
 	inline Int prtSize() const { return layout_.prtSize; }
 	inline Float prtPrice() const { return layout_.prtPrice; }
 	inline Int prtClusterNum() const { return layout_.prtClusterNum; }
@@ -3045,7 +3045,7 @@ private:
 		Float mrkPrice;
 		Float clsPrice;
 		StkPrintType prtType;
-		String<18> printCodes;
+		String<36> printCodes;
 		Byte prtCond1;
 		Byte prtCond2;
 		Byte prtCond3;
@@ -3086,7 +3086,7 @@ public:
 	inline Float mrkPrice() const { return layout_.mrkPrice; }
 	inline Float clsPrice() const { return layout_.clsPrice; }
 	inline StkPrintType prtType() const { return layout_.prtType; }
-	inline const String<18>& printCodes() const { return layout_.printCodes; }
+	inline const String<36>& printCodes() const { return layout_.printCodes; }
 	inline Byte prtCond1() const { return layout_.prtCond1; }
 	inline Byte prtCond2() const { return layout_.prtCond2; }
 	inline Byte prtCond3() const { return layout_.prtCond3; }

--- a/cpp/include/SpiderRock/DataFeed/Enums.h
+++ b/cpp/include/SpiderRock/DataFeed/Enums.h
@@ -319,8 +319,8 @@ namespace SpiderRock
 			NXML=12,
 			NXOS=13,
 			NXP=14,
-			ICEFE=15,
-			ICELF=16
+			ICEFEC=15,
+			ICEFEF=16
 		};
 
  		enum class GridType : Enum 
@@ -529,8 +529,8 @@ namespace SpiderRock
 			NXML=32,
 			NXOS=33,
 			NXP=34,
-			ICEFE=35,
-			ICELF=36
+			ICEFEC=35,
+			ICEFEF=36
 		};
 
  		enum class OptPriceInc : Enum 
@@ -1024,8 +1024,8 @@ namespace SpiderRock
 			NXP=39,
 			EUREX=40,
 			CEDX=41,
-			ICEFE=42,
-			ICELF=43
+			ICEFEC=42,
+			ICEFEF=43
 		};
 
  		enum class TimeInForce : Enum 
@@ -1143,7 +1143,11 @@ namespace SpiderRock
 			EU_NL=69,
 			EU_NO=70,
 			EU_PT=71,
-			EU_SE=72
+			EU_SE=72,
+			EU_ES=73,
+			EU_CZ=74,
+			EU_HU=75,
+			EU_PL=76
 		};
 
  		enum class UnderlierMode : Enum 

--- a/csharp/SpiderRock.DataFeed/Enums.Auto.cs
+++ b/csharp/SpiderRock.DataFeed/Enums.Auto.cs
@@ -34,7 +34,7 @@ namespace SpiderRock.DataFeed
  	public enum ExpirationMap : byte { None=0,ExactMatch=1,UnderlierMap=2 };		
  	public enum FirmType : byte { None=0,Customer=1,Firm=2,MarketMaker=3,ProCustomer=4,BrokerDealer=5,AwayMM=6,FirmJBO=7,BrkrDlrCust=8 };		
  	public enum FitPath : byte { None=0,VolUPrc=2,VolUPrcDefault=3,VolSDiv=4,VolSDivDefault=5,BaseDefault=6,BaseDefaultAdj=7,HistVol=8,Default=9,NormalMid=10,WideMid=11,WideGap=12,WideBound=13,AtmRange=14 };		
- 	public enum FutExch : byte { None=0,CFE=1,CME=2,CBOT=3,COMEX=4,NYMEX=5,ICE=6,EUREX=7,CEDX=8,NXAM=9,NXBR=10,NXLS=11,NXML=12,NXOS=13,NXP=14,ICEFE=15,ICELF=16 };		
+ 	public enum FutExch : byte { None=0,CFE=1,CME=2,CBOT=3,COMEX=4,NYMEX=5,ICE=6,EUREX=7,CEDX=8,NXAM=9,NXBR=10,NXLS=11,NXML=12,NXOS=13,NXP=14,ICEFEC=15,ICEFEF=16 };		
  	public enum GridType : byte { None=0,Unused=1,SRCubic=2,SRCubic2=3,BSpline=4,BSpline2=5 };		
  	public enum IdxSrc : byte { Unknown=0,Indication=1,Quote=2 };		
  	public enum ImbalanceSide : byte { None=0,Buy=1,Sell=2,NoImbalance=3,InsufOrdsToCalc=4 };		
@@ -50,7 +50,7 @@ namespace SpiderRock.DataFeed
  	public enum OTCPrimaryMarket : byte { None=0,OTCLink=1,OTCBB=2,OTCLinkBB=3,GreyMarket=4,OTCBonds=5 };		
  	public enum OTCTier : byte { None=0,OtcNoTier=1,OTCQXUSPrem=2,OTCQXUS=3,OTCQXIntPrem=4,OTCQXInt=5,OTCQB=6,OTCBBOnly=7,PinkCurr=8,PinkLim=9,PinkNoInfo=10,Grey=11,Expert=12,OTCBonds=13 };		
  	[System.Flags] public enum OpraMktType : byte { None=0,Rotation=1,TradingHalted=2,CustInterest=4,QuoteNotFirm=8,Indicative=16,AutoEligible=32 };		
- 	public enum OptExch : byte { None=0,AMEX=1,BOX=2,CBOE=3,ISE=4,NYSE=5,PHLX=6,NSDQ=7,BATS=8,C2=9,NQBX=10,MIAX=11,GMNI=12,CME=13,CBOT=14,NYMEX=15,COMEX=16,ICE=17,EDGO=18,MCRY=19,MPRL=20,SDRK=21,DQTE=22,EMLD=23,CFE=24,MEMX=25,SPHR=26,EUREX=27,CEDX=28,NXAM=29,NXBR=30,NXLS=31,NXML=32,NXOS=33,NXP=34,ICEFE=35,ICELF=36 };		
+ 	public enum OptExch : byte { None=0,AMEX=1,BOX=2,CBOE=3,ISE=4,NYSE=5,PHLX=6,NSDQ=7,BATS=8,C2=9,NQBX=10,MIAX=11,GMNI=12,CME=13,CBOT=14,NYMEX=15,COMEX=16,ICE=17,EDGO=18,MCRY=19,MPRL=20,SDRK=21,DQTE=22,EMLD=23,CFE=24,MEMX=25,SPHR=26,EUREX=27,CEDX=28,NXAM=29,NXBR=30,NXLS=31,NXML=32,NXOS=33,NXP=34,ICEFEC=35,ICEFEF=36 };		
  	public enum OptPriceInc : byte { None=0,PartPenny=1,PartNickle=2,FullPenny=3 };		
  	public enum OptionType : byte { None=0,Equity=1,Index=2,Future=3,Binary=4,Warrant=5,Flex=6,MapError=99 };		
  	public enum PositionType : byte { None=0,Opening=1,Closing=2,Auto=3 };		
@@ -73,13 +73,13 @@ namespace SpiderRock.DataFeed
  	public enum SurfaceResult : byte { None=0,OK=1,EOD=2,Init=3,Cache=4,PrevDay=5,NullExpIdx=6,NoStrikes=7,NoBaseCurve=8,BadBootAtm=9,NoGoodStrikes=10,BadAtmVol=11,Bootstrap=12,NoUPrc=13,NoIVols=14,NoModelPts=15,ZeroYears=16,NoSimpleVol=17,OptMktNotOpn=18,NoBaseSurface=19,UPrcOffCnt=20,SkewKnotCnt=21,Exception=22,AxisError=23,CAskFit1Err=24,CAskFit2Err=25,PAskFit1Err=26,PAskFit2Err=27,CBidFit1Err=28,CBidFit2Err=29,PBidFit1Err=30,PBidFit2Err=31,CobsSampleErr=32,NoPrcFit=33,NumStrikes=34,CMidFitErr=35,PMidFitErr=36,StrikeCount=37,VolKnotCnt=38,InterpError=39,NoAtmStrike=40,CobsConvexFitErr=41,CobsMidFitErr=42,ProxyError=43,NoOptExp=44,Expired=45,NoUnderlier=46,NoBaseUnderlier=47,InvalidUPrc=48,ZeroUPrc=49,WideUMkt=50,StalePrcFit=51,NoPrcCurves=52,PriceError=53,ConvergeFail=54 };		
  	public enum SymbolType : byte { None=0,Equity=1,ADR=2,ETF=3,CashIndex=4,MutualFund=5,ShortETF=6,Future=7,Bond=8,DepReceipts=9,PreferredSec=10,PreferenceShare=11,StructuredProd=12,StapledSec=13,TradeableRights=14,Unit=15,Warrant=16,WhenIssued=17,ForeignIssue=18 };		
  	public enum SysEnvironment : byte { None=0,Neptune=1,Pluto=2,V7_Stable=3,V7_Latest=4,Saturn=5,Venus=6,Mars=7,SysTest=8,V7_Current=9 };		
- 	public enum TickerSrc : byte { None=0,SR=1,NMS=2,CME=3,ICE=4,CFE=5,CBOT=6,TD=7,NYMEX=8,COMEX=9,RUT=10,CBOE=11,ISE=12,ARCA=13,NYSE=14,OTC=15,TST1=16,TST2=17,TST3=18,TST=19,USR1=20,USR2=21,USR3=22,NSDQ=23,MFQS=24,PHLX=25,MIAX=26,TSE=27,DJI=28,CBX=29,BXE=30,SCE=31,CXE=32,DXE=33,NXAM=34,NXBR=35,NXLS=36,NXML=37,NXOS=38,NXP=39,EUREX=40,CEDX=41,ICEFE=42,ICELF=43 };		
+ 	public enum TickerSrc : byte { None=0,SR=1,NMS=2,CME=3,ICE=4,CFE=5,CBOT=6,TD=7,NYMEX=8,COMEX=9,RUT=10,CBOE=11,ISE=12,ARCA=13,NYSE=14,OTC=15,TST1=16,TST2=17,TST3=18,TST=19,USR1=20,USR2=21,USR3=22,NSDQ=23,MFQS=24,PHLX=25,MIAX=26,TSE=27,DJI=28,CBX=29,BXE=30,SCE=31,CXE=32,DXE=33,NXAM=34,NXBR=35,NXLS=36,NXML=37,NXOS=38,NXP=39,EUREX=40,CEDX=41,ICEFEC=42,ICEFEF=43 };		
  	public enum TimeInForce : byte { None=0,Day=1,IOC=2,GTD=3,ExtDay=4,Week=5,ExtWeek=6 };		
  	public enum TimeMetric : byte { None=0,D252=1,D365=2,SPX=3,WK1=4,WK2=5,WK3=6,WK4=7 };		
  	public enum TkDefSource : byte { None=0,Vendor=1,OTC=2,SR=3,Exchange=4 };		
  	public enum TkStatusFlag : byte { None=0,Active=1,Delisted=2 };		
  	public enum TradeableStatus : byte { None=0,OK=1,SurfaceErr=2,LowCCnt=3,LowPCnt=4,FitPrcErr=5,BidAskMiss=6,LowCounter=7,DefaultSkew=8,SessionMiss=9,BaseErr=10,SwitchDelay=11,WideMktV=12,WideMktP=13,WideUMkt=14,UWidthEma=15,CCntEma=16,PCntEma=17,VWidthEma=18,PWidthEma=19,Closed=20 };		
- 	public enum TradingPeriod : byte { None=0,NMS=1,NMS_EXT=2,NMS_GTH=3,CME_ES=10,CME_GRAIN=11,CME_TRSY=12,CME_ENGY=13,CME_METAL=14,CME_FX=15,CME_COMD=16,CME_CRYP=17,CME_DAIRY=18,CME_EQBTIC=19,CME_NKBTIC=20,CME_WEATHER=21,CME_TACO=22,CME_TPXBTIC=23,CME_FTSE=24,CME_BMD=25,CME_BOVESPA=26,CME_EQTMAC=27,CME_TAM=28,CME_OTHER=29,CFE=30,ICE_US=32,ICE_EU=35,SCE=50,EU_ERX=51,EU_CBOE=52,EU_NXAM=53,EU_NXBR=54,EU_NXLS=55,EU_NXML=56,EU_NXOS=57,EU_NXP=58,EU_AT=59,EU_BE=60,EU_CH=61,EU_DE=62,EU_DK=63,EU_FI=64,EU_FR=65,EU_GB=66,EU_IE=67,EU_IT=68,EU_NL=69,EU_NO=70,EU_PT=71,EU_SE=72 };		
+ 	public enum TradingPeriod : byte { None=0,NMS=1,NMS_EXT=2,NMS_GTH=3,CME_ES=10,CME_GRAIN=11,CME_TRSY=12,CME_ENGY=13,CME_METAL=14,CME_FX=15,CME_COMD=16,CME_CRYP=17,CME_DAIRY=18,CME_EQBTIC=19,CME_NKBTIC=20,CME_WEATHER=21,CME_TACO=22,CME_TPXBTIC=23,CME_FTSE=24,CME_BMD=25,CME_BOVESPA=26,CME_EQTMAC=27,CME_TAM=28,CME_OTHER=29,CFE=30,ICE_US=32,ICE_EU=35,SCE=50,EU_ERX=51,EU_CBOE=52,EU_NXAM=53,EU_NXBR=54,EU_NXLS=55,EU_NXML=56,EU_NXOS=57,EU_NXP=58,EU_AT=59,EU_BE=60,EU_CH=61,EU_DE=62,EU_DK=63,EU_FI=64,EU_FR=65,EU_GB=66,EU_IE=67,EU_IT=68,EU_NL=69,EU_NO=70,EU_PT=71,EU_SE=72,EU_ES=73,EU_CZ=74,EU_HU=75,EU_PL=76 };		
  	public enum UnderlierMode : byte { None=0,Actual=1,FrontMonth=2,UPrcAdj=3 };		
  	public enum UpdateType : byte { None=0,PrcChange=1,SizeOnly=2,PrevPeriod=3 };		
  	public enum VolumeTier : byte { None=0,Top50=1 };		

--- a/csharp/SpiderRock.DataFeed/Layouts/FixedStrings.Auto.cs
+++ b/csharp/SpiderRock.DataFeed/Layouts/FixedStrings.Auto.cs
@@ -780,209 +780,6 @@ namespace SpiderRock.DataFeed.Layouts
 	}
  	
 	[StructLayout(LayoutKind.Sequential, Pack = 1, CharSet = CharSet.Ansi)]
-	internal unsafe struct FixedString18Layout : IEquatable<FixedString18Layout>, IComparable<FixedString18Layout>, IEquatable<string>
-	{
-		public fixed byte chars[18];
-
-		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public override string ToString()
-		{
-			return Value;
-		}
-		
-		public int Length
-		{
-			[MethodImpl(MethodImplOptions.AggressiveInlining)]
-			get
-			{
-				unchecked
-				{
-					fixed (byte* charsPtr = chars)
-					{
-						for (int i = 0; i < 18; i++) 
-						{
-							if (charsPtr[i] == 0) return i;
-						}
-						return 18;
-					}
-				}
-			}
-		}
-		
-		public int MaxLength { get { return 18; } }
-
-        public bool IsEmpty
-        {
-            [MethodImpl(MethodImplOptions.AggressiveInlining)] get { fixed (byte* pfchars = chars) return *pfchars == 0; }
-        }
-		
-		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public bool Equals(FixedString18Layout other)
-		{
-			fixed (FixedString18Layout* pfself = &this)
-			{
-				/* -------------- compare as ints ------------ */
-				var pIntSelf = (int*) pfself;
-				var pIntOther = (int*) &other;
-				for (int i = 0; i < 4; i++)
-				{
-					if (*(pIntSelf++) == *(pIntOther++)) continue;
-					return false;
-				}
- 				/* -------------- compare as bytes ------------ */
-				var pByteSelf = (byte*) pIntSelf;
-				var pByteOther = (byte*) pIntOther;
- 		
-				for (int i = 0; i < 2; i++)
-				{
-					if (*(pByteSelf++) == *(pByteOther++)) continue;
-					return false;
-				}
- 				return true;
-
-			}
-		}
-		
-		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public bool Equals(string value)
-		{
-			unchecked
-			{
-				fixed (byte* charsPtr = chars)
-				fixed (char* valuePtr = value)
-				{
-					int i = 0;
-					while (i < 18) 
-					{
-						byte mine = charsPtr[i]; 
-						byte theirs = (byte) valuePtr[i];
-						if (mine != theirs) return false;
-						if (mine == 0 || theirs == 0) break;
-						++i;
-					}
-					return i == value.Length;
-				}
-			}
-		}
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public int CompareTo(FixedString18Layout other)
-        {
-			unchecked
-			{
-				fixed (byte* pfchars = chars)
-				{
-					var pother = (byte*) &other;
-					for (int i = 0; i < 18; i++)
-					{
-						int result = *(pfchars + i) - *(pother + i);
-						if (result == 0) continue;
-						return result;
-					}
-					return 0;
-				}
-			}
-        }
-
-	    public string Value
-	    {
-			[MethodImpl(MethodImplOptions.AggressiveInlining)]
-	        get
-			{
-				fixed (byte* charsPtr = chars)
-				{
-					int length = Length;
-					return length == 0 ? string.Empty : new string((sbyte*) charsPtr, 0, Length, System.Text.Encoding.ASCII);
-				}
-			}
-			
-	        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-			set
-			{
-				unchecked
-				{
-					fixed (byte* charsPtr = chars)
-					fixed (char* valuePtr = value)
-					{
-						char* pstr = valuePtr;
-						byte* pchars = charsPtr;
-						
-						if (value.Length >= 18)
-						{
-							for (int i = 0; i < 18; i++) { *(pchars++) = (byte) *(pstr++); }
-						}
-						else
-						{
-							while (*pstr != 0) { *(pchars++) = (byte) *(pstr++); }
-							*pchars = 0;
-						}
-					}
-				}
-			}
-	    }
-		
-		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public void TrimEnd()
-		{
-			unchecked
-			{
-				fixed (byte* begPtr = chars)
-				{
-					byte* endPtr = begPtr + 17;
-					
-					for (int i = 0; i < 18; i++)
-					{
-						if (*endPtr == 32)
-						{
-							*(endPtr--) = 0;
-							continue;
-						}
-						break;
-					}
-				}
-			}
-		}
-		
-		public override int GetHashCode()
-		{
-			fixed (FixedString18Layout* pfself = &this)
-			{
-				int hashCode = 37;
-				/* -------------- hash as ints ------------ */
-				var pIntSelf = (int*) pfself;
-				for (int i = 0; i < 4; i++)
-				{
-					hashCode = (hashCode*397) ^ *(pIntSelf++);
-				}
- 				/* -------------- hash as bytes ------------ */
-				var pByteSelf = (byte*) pIntSelf;
- 		
-				for (int i = 0; i < 2; i++)
-				{
-					hashCode = (hashCode*397) ^ *(pByteSelf++);
-				}
-
-				return hashCode;
-			}
-		}
-
-		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static implicit operator string(FixedString18Layout value)
-		{
-			return value.Value;
-		}
-
-		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static implicit operator FixedString18Layout(string value)
-		{
-			var r = new FixedString18Layout();
-			if (string.IsNullOrEmpty(value)) return r;
-			r.Value = value;
-			return r;
-		}
-	}
- 	
-	[StructLayout(LayoutKind.Sequential, Pack = 1, CharSet = CharSet.Ansi)]
 	internal unsafe struct FixedString2Layout : IEquatable<FixedString2Layout>, IComparable<FixedString2Layout>, IEquatable<string>
 	{
 		public fixed byte chars[2];
@@ -2492,6 +2289,193 @@ namespace SpiderRock.DataFeed.Layouts
 		public static implicit operator FixedString32Layout(string value)
 		{
 			var r = new FixedString32Layout();
+			if (string.IsNullOrEmpty(value)) return r;
+			r.Value = value;
+			return r;
+		}
+	}
+ 	
+	[StructLayout(LayoutKind.Sequential, Pack = 1, CharSet = CharSet.Ansi)]
+	internal unsafe struct FixedString36Layout : IEquatable<FixedString36Layout>, IComparable<FixedString36Layout>, IEquatable<string>
+	{
+		public fixed byte chars[36];
+
+		[MethodImpl(MethodImplOptions.AggressiveInlining)]
+		public override string ToString()
+		{
+			return Value;
+		}
+		
+		public int Length
+		{
+			[MethodImpl(MethodImplOptions.AggressiveInlining)]
+			get
+			{
+				unchecked
+				{
+					fixed (byte* charsPtr = chars)
+					{
+						for (int i = 0; i < 36; i++) 
+						{
+							if (charsPtr[i] == 0) return i;
+						}
+						return 36;
+					}
+				}
+			}
+		}
+		
+		public int MaxLength { get { return 36; } }
+
+        public bool IsEmpty
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)] get { fixed (byte* pfchars = chars) return *pfchars == 0; }
+        }
+		
+		[MethodImpl(MethodImplOptions.AggressiveInlining)]
+		public bool Equals(FixedString36Layout other)
+		{
+			fixed (FixedString36Layout* pfself = &this)
+			{
+				/* -------------- compare as ints ------------ */
+				var pIntSelf = (int*) pfself;
+				var pIntOther = (int*) &other;
+				for (int i = 0; i < 9; i++)
+				{
+					if (*(pIntSelf++) == *(pIntOther++)) continue;
+					return false;
+				}
+ 				return true;
+
+			}
+		}
+		
+		[MethodImpl(MethodImplOptions.AggressiveInlining)]
+		public bool Equals(string value)
+		{
+			unchecked
+			{
+				fixed (byte* charsPtr = chars)
+				fixed (char* valuePtr = value)
+				{
+					int i = 0;
+					while (i < 36) 
+					{
+						byte mine = charsPtr[i]; 
+						byte theirs = (byte) valuePtr[i];
+						if (mine != theirs) return false;
+						if (mine == 0 || theirs == 0) break;
+						++i;
+					}
+					return i == value.Length;
+				}
+			}
+		}
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+		public int CompareTo(FixedString36Layout other)
+        {
+			unchecked
+			{
+				fixed (byte* pfchars = chars)
+				{
+					var pother = (byte*) &other;
+					for (int i = 0; i < 36; i++)
+					{
+						int result = *(pfchars + i) - *(pother + i);
+						if (result == 0) continue;
+						return result;
+					}
+					return 0;
+				}
+			}
+        }
+
+	    public string Value
+	    {
+			[MethodImpl(MethodImplOptions.AggressiveInlining)]
+	        get
+			{
+				fixed (byte* charsPtr = chars)
+				{
+					int length = Length;
+					return length == 0 ? string.Empty : new string((sbyte*) charsPtr, 0, Length, System.Text.Encoding.ASCII);
+				}
+			}
+			
+	        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+			set
+			{
+				unchecked
+				{
+					fixed (byte* charsPtr = chars)
+					fixed (char* valuePtr = value)
+					{
+						char* pstr = valuePtr;
+						byte* pchars = charsPtr;
+						
+						if (value.Length >= 36)
+						{
+							for (int i = 0; i < 36; i++) { *(pchars++) = (byte) *(pstr++); }
+						}
+						else
+						{
+							while (*pstr != 0) { *(pchars++) = (byte) *(pstr++); }
+							*pchars = 0;
+						}
+					}
+				}
+			}
+	    }
+		
+		[MethodImpl(MethodImplOptions.AggressiveInlining)]
+		public void TrimEnd()
+		{
+			unchecked
+			{
+				fixed (byte* begPtr = chars)
+				{
+					byte* endPtr = begPtr + 35;
+					
+					for (int i = 0; i < 36; i++)
+					{
+						if (*endPtr == 32)
+						{
+							*(endPtr--) = 0;
+							continue;
+						}
+						break;
+					}
+				}
+			}
+		}
+		
+		public override int GetHashCode()
+		{
+			fixed (FixedString36Layout* pfself = &this)
+			{
+				int hashCode = 37;
+				/* -------------- hash as ints ------------ */
+				var pIntSelf = (int*) pfself;
+				for (int i = 0; i < 9; i++)
+				{
+					hashCode = (hashCode*397) ^ *(pIntSelf++);
+				}
+
+				return hashCode;
+			}
+		}
+
+		[MethodImpl(MethodImplOptions.AggressiveInlining)]
+		public static implicit operator string(FixedString36Layout value)
+		{
+			return value.Value;
+		}
+
+		[MethodImpl(MethodImplOptions.AggressiveInlining)]
+		public static implicit operator FixedString36Layout(string value)
+		{
+			var r = new FixedString36Layout();
 			if (string.IsNullOrEmpty(value)) return r;
 			r.Value = value;
 			return r;

--- a/csharp/SpiderRock.DataFeed/Messages.Auto.cs
+++ b/csharp/SpiderRock.DataFeed/Messages.Auto.cs
@@ -4163,7 +4163,7 @@ namespace SpiderRock.DataFeed
 			public int prtClusterNum;
 			public int prtClusterSize;
 			public byte prtType;
-			public FixedString18Layout printCodes;
+			public FixedString36Layout printCodes;
 			public ushort prtOrders;
 			public int prtVolume;
 			public int cxlVolume;
@@ -4190,7 +4190,7 @@ namespace SpiderRock.DataFeed
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
 		internal void Invalidate() { ++usn; }
 		
- 		private CachedFixedLengthString<FixedString18Layout> printCodes;
+ 		private CachedFixedLengthString<FixedString36Layout> printCodes;
 		
 
 
@@ -4463,7 +4463,7 @@ namespace SpiderRock.DataFeed
 		internal struct BodyLayout
 		{
 			public OptExch prtExch;
-			public FixedString18Layout printCodes;
+			public FixedString36Layout printCodes;
 			public int prtSize;
 			public float prtPrice;
 			public int prtClusterNum;
@@ -4504,7 +4504,7 @@ namespace SpiderRock.DataFeed
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
 		internal void Invalidate() { ++usn; }
 		
- 		private CachedFixedLengthString<FixedString18Layout> printCodes;
+ 		private CachedFixedLengthString<FixedString36Layout> printCodes;
 		
 
 
@@ -8633,7 +8633,7 @@ namespace SpiderRock.DataFeed
 			public float mrkPrice;
 			public float clsPrice;
 			public StkPrintType prtType;
-			public FixedString18Layout printCodes;
+			public FixedString36Layout printCodes;
 			public byte prtCond1;
 			public byte prtCond2;
 			public byte prtCond3;
@@ -8657,7 +8657,7 @@ namespace SpiderRock.DataFeed
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
 		internal void Invalidate() { ++usn; }
 		
- 		private CachedFixedLengthString<FixedString18Layout> printCodes;
+ 		private CachedFixedLengthString<FixedString36Layout> printCodes;
 		
 
 
@@ -8667,7 +8667,7 @@ namespace SpiderRock.DataFeed
 		/// <summary>print size</summary>
         public int PrtSize { get { return body.prtSize; } set { body.prtSize = value; } }
  
-		/// <summary>print size today in fractional qty</summary>
+		/// <summary>print size with fractional qts</summary>
         public float PrtSizeFractional { get { return body.prtSizeFractional; } set { body.prtSizeFractional = value; } }
  
 		/// <summary>print size has fractional qty</summary>
@@ -8688,7 +8688,7 @@ namespace SpiderRock.DataFeed
 		/// <summary>cumulative print size today</summary>
         public int PrtVolume { get { return body.prtVolume; } set { body.prtVolume = value; } }
  
-		/// <summary>cumulative print size fractional today</summary>
+		/// <summary>cumulative fractional size of prints in this sequence (prints @ same or more aggressive price with less than 25 ms elapsing since first print; can span exchanges)</summary>
         public float PrtVolumeFractional { get { return body.prtVolumeFractional; } set { body.prtVolumeFractional = value; } }
  
 		/// <summary>last regular market print price</summary>


### PR DESCRIPTION
# PR #45 — SpiderStream updates 20260510

This ports the same SpiderStream schema updates to the older v7/SRDataFeed system.

---

## `printCodes` Field Width Expansion

**Affected messages:** `OptionPrint`, `OptionPrintMarkup`, `StockPrint`  
**Affected files:** `CoreMessages.h`, `Messages.Auto.cs`, `FixedStrings.Auto.cs`

The `printCodes` fixed-length string field has been doubled in width across all three message types, in both C++ and C#:

| Before | After |
|---|---|
| `String<18>` / `FixedString18Layout` | `String<36>` / `FixedString36Layout` |

This affects struct field declarations and accessor methods in C++, and struct fields plus `CachedFixedLengthString<>` backing fields in C#.

The underlying C# layout type `FixedString18Layout` has been entirely removed and replaced with a new `FixedString36Layout`. The new implementation is functionally equivalent — same unsafe struct pattern with `fixed byte chars[N]`, ASCII encoding, `IEquatable`, `IComparable`, implicit string conversion operators — but sized for 36 bytes. Notably, the equality comparison loop count changes from 4+2 int/byte iterations to 9 int iterations (36 bytes divides evenly into 9 ints, so the trailing byte loop is gone).

This is a **binary breaking change** — struct sizes change for all three message types and any code deserializing by fixed offset or buffer size will be affected.

---

## Enum Renames

Two ICE exchange codes renamed across three enums in both C++ (`Enums.h`) and C# (`Enums.Auto.cs`). Numeric values are unchanged.

| Old name | New name | Enums affected |
|---|---|---|
| `ICEFE` | `ICEFEC` | `FutExch` (15), `OptExch` (35), `TickerSrc` (42) |
| `ICELF` | `ICEFEF` | `FutExch` (16), `OptExch` (36), `TickerSrc` (43) |

Any code referencing these by name rather than numeric value will need updating.

---

## Enum Extensions

### `TradingPeriod` (C++ and C#)

Four new EU market codes appended, matching the SpiderStream-Connect-SDK PR #40 update:

| Value | Code | Market |
|---|---|---|
| 73 | `EU_ES` | Spain |
| 74 | `EU_CZ` | Czech Republic |
| 75 | `EU_HU` | Hungary |
| 76 | `EU_PL` | Poland |

---

## Doc String Fixes (`Messages.Auto.cs`)

Two `StockPrint` field summaries corrected:

| Field | Old description | New description |
|---|---|---|
| `PrtSizeFractional` | "print size today in fractional qty" | "print size with fractional qts" |
| `PrtVolumeFractional` | "cumulative print size fractional today" | "cumulative fractional size of prints in this sequence (prints @ same or more aggressive price with less than 25 ms elapsing since first print; can span exchanges)" |

The `PrtVolumeFractional` correction is substantive — the new description clarifies the clustering semantics (time-windowed, price-conditioned, cross-exchange).
